### PR TITLE
Fix functions to accept currencyName set to 'default' or ''

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- fix `give`, `spend` and `hasFunds` to accept the currency name argument set to 'default' or '' ([#6](https://github.com/seaofvoices/crosswalk-currency/pull/6))
+
 ## 0.1.1
 
 - fix initial currency data not being sent after data is loaded ([#3](https://github.com/seaofvoices/crosswalk-currency/pull/3))


### PR DESCRIPTION
Closes #5 

Functions `give`, `spend` and `hasFunds` now works if the currency name is set to `'default'` or `''` (that will select the default currency)

- [x] add entry to the changelog
