### PR TITLE
Add `Currency.tryGive` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- add `Currency.tryGive` that returns `true` if the currency was given to the player, or `false` if the player data is not available ([#7](https://github.com/seaofvoices/crosswalk-currency/pull/7))
 - fix `give`, `spend` and `hasFunds` to accept the currency name argument set to 'default' or '' ([#6](https://github.com/seaofvoices/crosswalk-currency/pull/6))
 
 ## 0.1.1

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ Currency.give(player: Player, amount: number, currencyName?: string)
 
 Give currency to a player. If `currencyName` is provided, the specified custom currency will be incremented; otherwise, the default currency will be incremented.
 
+Throws an error if the player data is not available.
+
+### `tryGive`
+
+```lua
+Currency.tryGive(player: Player, amount: number, currencyName?: string): boolean
+```
+
+Give currency to a player. If `currencyName` is provided, the specified custom currency will be incremented; otherwise, the default currency will be incremented.
+
+Returns `false` if the player data is not available.
+
 ### `spend`
 
 ```lua

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,6 +1,6 @@
 [tools]
-darklua = { github = "seaofvoices/darklua", version = "=0.12.1"}
-luau-lsp = { github = "JohnnyMorganz/luau-lsp", version = "=1.27.1"}
+darklua = { github = "seaofvoices/darklua", version = "=0.13.1"}
+luau-lsp = { github = "JohnnyMorganz/luau-lsp", version = "=1.32.0"}
 rojo = { github = "rojo-rbx/rojo", version = "=7.4.0"}
-selene = { github = "Kampfkarren/selene", version = "=0.26.1"}
+selene = { github = "Kampfkarren/selene", version = "=0.27.1"}
 stylua = { github = "JohnnyMorganz/StyLua", version = "=0.20.0"}

--- a/src/init.lua
+++ b/src/init.lua
@@ -89,6 +89,36 @@ return function(Modules, _, _)
         sendToChannel(player, data, customCurrency)
     end
 
+    function module.tryGive(player: Player, amount: number, currencyName: string?): boolean
+        if amount == 0 then
+            return true
+        end
+
+        local data: Data? = playerDatas:tryGet(player)
+
+        if data == nil then
+            return false
+        end
+
+        local data = data :: Data
+
+        local customCurrency = getCustomCurrency(currencyName)
+
+        if customCurrency == nil then
+            data.default += amount
+        else
+            if _G.DEV then
+                verifyCurrencyName(customCurrency)
+            end
+            local custom = data.custom
+            custom[customCurrency] = amount + (custom[customCurrency] or 0)
+        end
+
+        sendToChannel(player, data, customCurrency)
+
+        return true
+    end
+
     function module.spend(player: Player, amount: number, currencyName: string?): boolean
         local data: Data = playerDatas:expect(player)
 


### PR DESCRIPTION
Add a `tryGive` function that will not error if the player data is not found. The function returns `true` if it is able to give the currency or `false` otherwise. 

- [x] add entry to the changelog
