### PR TITLE
Add economy event logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- add economy event logging ([#14](https://github.com/seaofvoices/crosswalk-currency/pull/14))
+
 ## 0.1.3
 
 - add `Currency.get` function ([#12](https://github.com/seaofvoices/crosswalk-currency/pull/12))


### PR DESCRIPTION
This PR connects with the Analytics module and add an optional argument to the `give`, `tryGive` and `spend` functions to pass the transaction type.

The `configure` function is added to enable the analytics reporting.

- [x] add entry to the changelog
